### PR TITLE
Exposed the sampleGoldenSpecWithEncoding function to the public API

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 ## Changes
 
+### 5.0.1
+* Exposed the sampleGoldenSpecWithEncoding function to the public API
+
 ### 5.0.0
 * Support for ReScript v11 with uncurried mode
 

--- a/lib/js/src/AesonSpec.js
+++ b/lib/js/src/AesonSpec.js
@@ -176,6 +176,19 @@ function encodingToString(encoding) {
   }
 }
 
+function sampleGoldenSpecWithEncoding(decode, encode, name_of_type, json_file, encoding) {
+  Jest.describe("AesonSpec.sampleGoldenSpec: " + (name_of_type + (" from file '" + (json_file + ("' with encoding " + encodingToString(encoding))))), (function () {
+          var json = JSON.parse(Nodefs.readFileSync(json_file).toString("utf8"));
+          Jest.testAll("decode then encode json_file", sampleJsonRoundtripSpec(decode, encode, json), (function (result) {
+                  if (result.TAG !== "Ok") {
+                    return Jest.fail(result._0);
+                  }
+                  var match = result._0;
+                  return Jest.Expect.toEqual(Jest.Expect.expect(match[0]), match[1]);
+                }));
+        }));
+}
+
 function isJsonFile(fileName) {
   var items = Core__List.fromArray(Js_string.split(".", fileName));
   var length = Js_list.length(items);
@@ -197,17 +210,7 @@ function goldenDirSpec(decode, encode, name_of_type, json_dir) {
 function goldenDirSpecWithEncoding(decode, encode, name_of_type, json_dir, encoding) {
   var files_in_dir = Js_array.filter(isJsonFile, Nodefs.readdirSync(json_dir));
   files_in_dir.forEach(function (json_file) {
-        var json_file$1 = json_dir + ("/" + json_file);
-        Jest.describe("AesonSpec.sampleGoldenSpec: " + (name_of_type + (" from file '" + (json_file$1 + ("' with encoding " + encodingToString(encoding))))), (function () {
-                var json = JSON.parse(Nodefs.readFileSync(json_file$1).toString("utf8"));
-                Jest.testAll("decode then encode json_file", sampleJsonRoundtripSpec(decode, encode, json), (function (result) {
-                        if (result.TAG !== "Ok") {
-                          return Jest.fail(result._0);
-                        }
-                        var match = result._0;
-                        return Jest.Expect.toEqual(Jest.Expect.expect(match[0]), match[1]);
-                      }));
-              }));
+        sampleGoldenSpecWithEncoding(decode, encode, name_of_type, json_dir + ("/" + json_file), encoding);
       });
 }
 
@@ -223,6 +226,7 @@ exports.sampleJsonRoundtripSpec = sampleJsonRoundtripSpec;
 exports.valueRoundtripSpec = valueRoundtripSpec;
 exports.goldenSpec = goldenSpec;
 exports.sampleGoldenSpec = sampleGoldenSpec;
+exports.sampleGoldenSpecWithEncoding = sampleGoldenSpecWithEncoding;
 exports.isJsonFile = isJsonFile;
 exports.goldenDirSpec = goldenDirSpec;
 exports.goldenDirSpecWithEncoding = goldenDirSpecWithEncoding;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plowtech/rescript-aeson-spec",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Test rescript-aeson encode and decode functions against golden files generated from the Haskell library hspec-golden-aeson",
   "main": "index.js",
   "scripts": {

--- a/src/AesonSpec.resi
+++ b/src/AesonSpec.resi
@@ -43,6 +43,14 @@ let goldenSpec: (Js_json.t => result<'a, string>, 'a => Js_json.t, string, strin
 
 let sampleGoldenSpec: (Js_json.t => result<'a, string>, 'a => Js_json.t, string, string) => unit
 
+let sampleGoldenSpecWithEncoding: (
+  Js.Json.t => Belt.Result.t<'a, string>,
+  Aeson.Encode.encoder<'a>,
+  string,
+  string,
+  [< #ascii | #base64 | #binary | #hex | #latin1 | #ucs2 | #utf16le | #utf8],
+) => unit
+
 @@ocaml.text(
   " encode a sample of a type, POST it to a test server, receive a response and decode the response "
 )


### PR DESCRIPTION
This was provided for `goldenDirSpec` but not for `sampleGoldenSpec`